### PR TITLE
Better reset and bugfixing for robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv/
 __pycache__
 out/
 *.rdb
+run_config.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 out/
 *.rdb
 run_config.json
+/*/*.pyc

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ space is simply a screenshot of the screen once the action has been taken. The r
 and design of the agent? That's left to experimentation. The project is called Multivac: a name found in
 Isaac Asimov's [The Last Question](http://www.physics.princeton.edu/ph115/LQ.pdf).
 
-Below is an example of a screen that a "random" agent lands on after 50 actions. This agent each step simply samples a coordinate uniformly at random.
+Below is an example of a screen that a "random" agent lands on after 50 actions. This agent each step simply samples 
+a coordinate uniformly at random.
 
 <img src="images/example_screenshot.png" width="200">
 
@@ -24,35 +25,36 @@ There are two separate environments to consider:
 1. Requirements by the Gym environment and agent side.
 2. Requirements on the `jython` side regarding the process that is started using the `monkeyrunner` cmd.
 
-Step by step instructions for setup:
+### Step by Step Instructions for Setup
 1. Clone the repository locally.
 2. Set up a python3.5 virtual environment for the project and activate the environment.
 3. Install all requirements listed under `requirements.txt` to this virtualenv.
    This can be done by, `pip install -r requirements.txt`. Once this has been completed,
    setup for the Gym environment and agent side has been complete.
 4. Download the Android SDK if not already. There should be the `monkeyrunner` tool under
-   `/Sdk/tools/bin/monkeyrunner`. Note the path to the `monkeyrunner` tool,
-   denoted `$MONKEYRUNNER_PATH` hereafter.
+   `/Sdk/tools/bin/monkeyrunner`. Note the path to the `monkeyrunner` tool.
 5. Unzip the `jythonCompatibleRedis.zip` located in this repo. This zip contains
    the `redispy` version `2.10.6` source with some syntax modifications to be
-   compatible with `jython`. Note the path to the unzipped source, denoted
-   `$REDISPY_PATH` hereafter.
+   compatible with `jython`. Note the path to the unzipped source.
+6. Under the root project directory, copy the contents of `example_run_config.json` to a new file `run_config.json`.
+   Change the values for they keys `monkeyrunner_path` and `redispy_path` to the appropriate local paths from steps
+   4 and 5. Use the template in `example_run_config.json` as a guide.
    
-Now, here are the instructions for running:
+### Running a Session from Command Line
 1. Connect an Android device either through USB or open an emulated device through
    Android Studio.
 2. Ensure the current working directory is right under `Multivac/` and the virtualenv
 from setup is activated. Then, launch the `session_starter.py` script as follows:
 ```bash
 export PYTHONPATH="${PYTHONPATH}:$(pwd)" &&
-python session/session_starter.py --monkeyrunner-path $MONKEYRUNNER_PATH --redispy-path $REDISPY_PATH --environment-name $ENV_NAME --agent-name $AGENT_NAME --num-train-steps $NUM_TRAIN_STEPS --num-inference-steps $NUM_INFERENCE_STEPS --observation-delta $OBS_DELTA
+python session/session_starter.py --environment-name $ENV_NAME --agent-name $AGENT_NAME --num-train-steps $NUM_TRAIN_STEPS --num-inference-steps $NUM_INFERENCE_STEPS --observation-delta $OBS_DELTA
 ```
 For a detailed description of all the parameters, run `python session/session_starter.py -h`.
 An example to launch a random agent for `50` inference steps using a basic reward function can
 be found below:
 ```bash
 export PYTHONPATH="${PYTHONPATH}:$(pwd)" &&
-python session/session_starter.py --monkeyrunner-path $MONKEYRUNNER_PATH --redispy-path $REDISPY_PATH --environment-name MeanPixelDifferenceEnv --agent-name random --num-train-steps 10 --num-inference-steps 50 --observation-delta 1000
+python session/session_starter.py --environment-name MeanPixelDifferenceEnv --agent-name random --num-train-steps 10 --num-inference-steps 50 --observation-delta 1000
 ```
 
 Once complete, a `mp4` file will be written to disk containing a recording, specifically

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ environment and preliminary experiments with launching RL
 agents on an Android device. More specifically, the action space 
 is 2 dimensional continuous down and up actions on the screen; the observation
 space is simply a screenshot of the screen once the action has been taken. The reward
-and design of the agent? That's left to experimentation. The project is called Multivac: a name found in
+and design of the agent? That's left to experimentation. The project is called Multivac: a name motivated by
 Isaac Asimov's [The Last Question](http://www.physics.princeton.edu/ph115/LQ.pdf).
 
 Below is an example of a screen that a "random" agent lands on after 50 actions. This agent each step simply samples 
@@ -47,14 +47,14 @@ There are two separate environments to consider:
 from setup is activated. Then, launch the `session_starter.py` script as follows:
 ```bash
 export PYTHONPATH="${PYTHONPATH}:$(pwd)" &&
-python session/session_starter.py --environment-name $ENV_NAME --agent-name $AGENT_NAME --num-train-steps $NUM_TRAIN_STEPS --num-inference-steps $NUM_INFERENCE_STEPS --observation-delta $OBS_DELTA
+python session/session_starter.py --environment-name $ENV_NAME --agent-name $AGENT_NAME --num-steps $NUM_STEPS --observation-delta $OBS_DELTA
 ```
 For a detailed description of all the parameters, run `python session/session_starter.py -h`.
-An example to launch a random agent for `50` inference steps using a basic reward function can
+An example to launch a random agent for `50` steps using a basic reward function can
 be found below:
 ```bash
 export PYTHONPATH="${PYTHONPATH}:$(pwd)" &&
-python session/session_starter.py --environment-name MeanPixelDifferenceEnv --agent-name random --num-train-steps 10 --num-inference-steps 50 --observation-delta 1000
+python session/session_starter.py --environment-name MeanPixelDifferenceEnv --agent-name random --num-steps 50 --observation-delta 1000
 ```
 
 Once complete, a `mp4` file will be written to disk containing a recording, specifically

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,3 @@
+find . -name "*.rdb" | xargs -r rm
+find . -name "*.class" | xargs -r rm
+find . -name "__pycache__" -not -path "./venv/*" | xargs -r rm -r

--- a/device/adb_shell_cmds/close_applications.sh
+++ b/device/adb_shell_cmds/close_applications.sh
@@ -1,0 +1,8 @@
+APPS=$(dumpsys window a | grep "/" | cut -d "{" -f2 | cut -d "/" -f1 | cut -d " " -f2)
+
+for APP in $APPS ; do
+  if [[ ! ("$APP" == *"nexuslauncher"*) ]]; then
+    echo "Closing: $APP"
+    pm clear $APP
+  fi
+done

--- a/device/adb_shell_cmds/shutdown_monkey_on_device.sh
+++ b/device/adb_shell_cmds/shutdown_monkey_on_device.sh
@@ -1,0 +1,1 @@
+killall com.android.commands.monkey

--- a/device/adb_shell_cmds_manager.py
+++ b/device/adb_shell_cmds_manager.py
@@ -1,0 +1,78 @@
+import os
+
+
+class AdbShellCmdsManager:
+    """
+    The AdbShellCmdsManager manages various custom adb shell commands related to interfacing with an android device
+    via the ConnectionClient.
+
+    Commands are stored in different bash files located in the device/adb_shell_cmds directory. The filenames without
+    the .sh extensions serve as names for the commands that a client can invoke through this manager.
+    """
+
+    BASE_PATH = "device/adb_shell_cmds"
+
+    # All possible commands
+    CLOSE_APPLICATIONS = "close_applications"
+    SHUTDOWN_MONKEY_ON_DEVICE = "shutdown_monkey_on_device"
+
+    ALL_COMMANDS = [CLOSE_APPLICATIONS, SHUTDOWN_MONKEY_ON_DEVICE]
+
+    def __init__(self, device):
+        """
+        Initialize an AdbShellsCmdsManager by parsing the bash files related to possible commands
+        :param device: MonkeyDevice instance that is used to carry out shell commands
+        """
+
+        self.device = device
+
+        # Iterate through the possible commands and retrieve parsed arguments
+        self.parsed_commands = dict()
+        for command in self.ALL_COMMANDS:
+            self.parsed_commands[command] = self.retrieve_command(command)
+
+    def take_command(self, command):
+        """
+        Invoke the passed in command on the device.
+        :param command: if part of self.parsed_commands, carry out the command on the device;
+                        otherwise, raise an Exception.
+        """
+
+        if command in self.parsed_commands:
+            self.device.shell(self.parsed_commands[command])
+        else:
+            raise Exception(str(command) + " is not a supported command")
+
+    def close_applications(self):
+        """
+        Close all applications on the device.
+        """
+
+        self.take_command(self.CLOSE_APPLICATIONS)
+
+    def shutdown_monkey_on_device(self):
+        """
+        Manually shutdown any processes relating to monkeyrunner on the device.
+        """
+
+        self.take_command(self.SHUTDOWN_MONKEY_ON_DEVICE)
+
+    @classmethod
+    def retrieve_command(cls, command):
+        """
+        Helper function that runs during initialization. It parses the appropriate bash file associated with command
+        to retrieve its contents as a string.
+        :param command: if part of ALL_COMMANDS, parse the associated bash file to retrieve the string contents;
+                        otherwise, raise an Exception.
+        :return string contents located in the bash file associated with command.
+        """
+
+        script_path = os.path.join(cls.BASE_PATH, str(command) + ".sh")
+
+        if os.path.exists(script_path):
+            fp = open(script_path, 'r')
+            contents = '\n'.join(fp.readlines())
+            fp.close()
+            return contents
+        else:
+            raise Exception(str(command) + " is not a supported command")

--- a/device/connection_client.py
+++ b/device/connection_client.py
@@ -98,3 +98,12 @@ class ConnectionClient:
         observation = Observation(img_bytes)
 
         self.observation_buffer.put_elem(observation)
+
+    def shutdown(self):
+        """
+        Shutdown the connection client.
+        """
+        print("Connection client shutting down.")
+
+        # Kill any monkey processes running on the device. This is required due to a bug in monkeyrunner itself
+        self.connected_device.shell('killall com.android.commands.monkey')

--- a/device/connection_client_starter.py
+++ b/device/connection_client_starter.py
@@ -6,7 +6,6 @@ This is a starter script for the connection_client. It requires the following cm
 It is best to call this using `session_starter.py`.
 """
 
-import atexit
 import os
 import signal
 import sys
@@ -26,8 +25,18 @@ from device.connection_client import ConnectionClient
 client = ConnectionClient(int(redis_port), int(observation_delta))
 
 
+def terminate_on_signal(signum, _):
+    client.shutdown()
+
+    # Graceful exit on sigterm since this is sent from parent process.
+    if signum == signal.SIGTERM:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
 # Gracefully exit on the SIGTERM signal. This is usually sent by the parent process.
-signal.signal(signal.SIGTERM, lambda signum, stack: client.shutdown())
+signal.signal(signal.SIGTERM, terminate_on_signal)
 
 # Start the connection client.
 client.start()

--- a/device/connection_client_starter.py
+++ b/device/connection_client_starter.py
@@ -27,11 +27,7 @@ client = ConnectionClient(int(redis_port), int(observation_delta))
 
 
 # Gracefully exit on the SIGTERM signal. This is usually sent by the parent process.
-def on_terminate(signum, stack):
-    print("Connection client shutting down.")
-
-
-signal.signal(signal.SIGTERM, on_terminate)
+signal.signal(signal.SIGTERM, lambda signum, stack: client.shutdown())
 
 # Start the connection client.
 client.start()

--- a/example_run_config.json
+++ b/example_run_config.json
@@ -1,0 +1,4 @@
+{
+  "monkeyrunner_path": "/home/<usr>/Android/Sdk/tools/bin/monkeyrunner",
+  "redispy_path": "/home/<usr>/Applications/redis-py-2.10.6"
+}

--- a/frontend/templates/css/main.css
+++ b/frontend/templates/css/main.css
@@ -184,6 +184,15 @@ iframe {
   padding-bottom: 44px;
 }
 
+.contact100-form-subtitle {
+  display: block;
+  font-family: Poppins-Regular;
+  font-size: 16px;
+  color: #333333;
+  line-height: 1.0;
+  text-align: left;
+  padding-bottom: 44px;
+}
 
 /*------------------------------------------------------------------
 [ Input ]*/

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -37,8 +37,8 @@
 
 				<span class="contact100-form-subtitle">
 					<p>
-						Fill in session parameters and launch a Multivac session! The launch config
-						file should already be setup; please see the
+						Fill in session parameters and launch a Multivac session! The `run_config.json` file should
+						already be added; please see the
 						<a href="https://github.com/SirjanK/Multivac/blob/master/README.md">README</a>
 						for more details on setup.
 					</p>

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -32,7 +32,20 @@
 		<div class="wrap-contact100">
 			<form class="contact100-form validate-form">
 				<span class="contact100-form-title">
-					Say Hello!
+                    Multivac Launcher
+				</span>
+
+				<span class="contact100-form-subtitle">
+					<p>
+						Fill in session parameters and launch a Multivac session! The launch config
+						file should already be setup; please see the
+						<a href="https://github.com/SirjanK/Multivac/blob/master/README.md">README</a>
+						for more details on setup.
+					</p>
+                    <p>
+						Once launched, the session will take place on the device/emulator. The video will be written
+						to disk under the <i>out</i> directory.
+					</p>
 				</span>
 
 				<div class="wrap-input100 validate-input" data-validate="Name is required">

--- a/session/multivac.py
+++ b/session/multivac.py
@@ -85,7 +85,7 @@ class Multivac:
         print("Resetting the environment.")
         curr_obs = self.environment.reset()
 
-        print("Starting to carry out inference for the agent.")
+        print("Starting to carry out steps for the agent.")
 
         total_reward = 0.0
         self.process_rendered_img(0, total_reward)

--- a/session/multivac.py
+++ b/session/multivac.py
@@ -1,4 +1,5 @@
 import cv2
+import logging
 import matplotlib.pyplot as plt
 import numpy as np
 import os
@@ -41,6 +42,10 @@ class Multivac:
                               execution.
         """
 
+        self.logger = logging.getLogger("Multivac")
+        self.logger.addHandler(logging.StreamHandler())
+        self.logger.setLevel(logging.DEBUG)
+
         # Start Redis connection on specified port.
         self.redis_client = redis.Redis(port=redis_port)
 
@@ -82,10 +87,10 @@ class Multivac:
         """
 
         # Reset the environment to its initial state. This also allows us to get an initial observation image.
-        print("Resetting the environment.")
+        self.logger.info("Resetting the environment.")
         curr_obs = self.environment.reset()
 
-        print("Starting to carry out steps for the agent.")
+        self.logger.info("Starting to carry out steps for the agent.")
 
         total_reward = 0.0
         self.process_rendered_img(0, total_reward)
@@ -96,8 +101,8 @@ class Multivac:
             total_reward += reward
             self.process_rendered_img(step, total_reward / step)
 
-        print("FINAL TOTAL REWARD: {}".format(total_reward))
-        print("FINAL AVERAGE REWARD: {}".format(total_reward / self.num_steps))
+        self.logger.info("FINAL TOTAL REWARD: {}".format(total_reward))
+        self.logger.info("FINAL AVERAGE REWARD: {}".format(total_reward / self.num_steps))
 
         self.video_writer.release()
 

--- a/session/session_starter.py
+++ b/session/session_starter.py
@@ -1,14 +1,16 @@
 """
-This is the starter script to launch a Multivac session. This entails two things:
-  1. Starting a connection client with an Android device
-  2. Starting a Multivac environment and agent to interface with the device
-For list of parameters required, run `python session/session_starter.py -h`.
+The session_starter script can be run via command line by supplying relevant parameters. It also provides the
+`start_multivac_session()` function to start the session from UI.
+
+For list of parameters required when run from the command line, run `python session/session_starter.py -h`.
 Run this script from the Multivac project directory.
 """
 
 
 import argparse
 import atexit
+import json
+import os
 import subprocess
 
 from agents.agent_registry import AGENTS
@@ -16,9 +18,11 @@ from environment.environment_registry import ENVIRONMENTS
 from session.multivac import Multivac
 
 # Input parameter keys.
-MONKEYRUNNER_PATH = "monkeyrunner-path"
-REDISPY_PATH = "redispy-path"
-MULTIVAC_VERSION = "multivac-version"
+# From config file
+MONKEYRUNNER_PATH = "monkeyrunner_path"
+REDISPY_PATH = "redispy_path"
+
+# From command line
 NUM_STEPS = "num-steps"
 OBSERVATION_DELTA = "observation-delta"
 ENVIRONMENT_NAME = "environment-name"
@@ -26,7 +30,8 @@ AGENT_NAME = "agent-name"
 VIDEO_FPS = "video-fps"
 DISPLAY_VIDEO = "display-video"
 
-# Fixed path
+# Fixed paths
+CFG_FILE_PATH = "run_config.json"
 CONNECTION_CLIENT_STARTER_SCRIPT_PATH = "device/connection_client_starter.py"
 
 DEFAULT_REDIS_PORT = 6379
@@ -65,6 +70,23 @@ def start_connection_client(monkeyrunner_path, redispy_path, redis_port, observa
     return connection_client_process
 
 
+def parse_config_file():
+    """
+    Parse the config file located at CFG_FILE_PATH; raise exception if the file does not exist.
+    :return: Path to monkeyrunner executable and path to redispy library.
+    """
+    assert os.path.exists(CFG_FILE_PATH), \
+        "{} cannot be found. Make sure to specify config file".format(CFG_FILE_PATH)
+
+    with open(CFG_FILE_PATH, 'r') as fp:
+        cfg_contents = json.load(fp)
+
+    monkeyrunner_path = cfg_contents[MONKEYRUNNER_PATH]
+    redispy_path = cfg_contents[REDISPY_PATH]
+
+    return monkeyrunner_path, redispy_path
+
+
 def parse_args():
     """
     Parse cmd line arguments.
@@ -82,17 +104,35 @@ def parse_args():
     parser.add_argument('--' + NUM_STEPS, type=int, required=True,
                         help="Number of steps to take on the environment before terminating.")
     parser.add_argument('--' + OBSERVATION_DELTA, type=int, required=False, default=250,
-                        help="Time to wait in milliseconds after taking an action in order to take a screenshot")
+                        help="Frame per second of the output recording of the gym environment. " +
+                             "Each frame will be one observation image.")
     parser.add_argument('--' + VIDEO_FPS, type=int, required=False, default=1,
                         help="Frame per second of the output recording of the gym environment. " +
                              "Each frame will be one observation image.")
-    parser.add_argument('--' + DISPLAY_VIDEO, default=False, action='store_true')
+    parser.add_argument('--' + DISPLAY_VIDEO, default=False, action='store_true',
+                        help="Flag to determine whether or not to manually display session in a window separate from "
+                             "the device/emulator or UI.")
 
     return parser.parse_args()
 
 
-if __name__ == '__main__':
-    params = parse_args()
+def start_multivac_session(environment_name, agent_name, num_steps, observation_delta=250, video_fps=1,
+                           display_video=False):
+    """
+    Start the Multivac session which includes:
+      1. Starting a connection client with an Android device
+      2. Starting a Multivac environment and agent to interface with the device
+
+    :param environment_name: Name of the environment to use.
+    :param agent_name: Name of the agent to use.
+    :param num_steps: Number of steps to take on the environment.
+    :param observation_delta: Time interval between observations.
+    :param video_fps: Frame per second of the output recording of the gym environment.
+    :param display_video: Flag to determine whether or not to manually display session in a window separate from the
+                          device/emulator or UI.
+    """
+    # Gather information from config file
+    monkeyrunner_path, redispy_path = parse_config_file()
 
     # Flush DB
     flush_redis_db()
@@ -102,20 +142,20 @@ if __name__ == '__main__':
 
     # Start connection client
     device_process = start_connection_client(
-        monkeyrunner_path=params.monkeyrunner_path,
-        redispy_path=params.redispy_path,
+        monkeyrunner_path=monkeyrunner_path,
+        redispy_path=redispy_path,
         redis_port=DEFAULT_REDIS_PORT,
-        observation_delta=params.observation_delta
+        observation_delta=observation_delta
     )
 
     # Set up the Multivac
     multivac = Multivac(
-        params.environment_name,
-        params.agent_name,
-        params.num_steps,
-        DEFAULT_REDIS_PORT,
-        video_fps=params.video_fps,
-        display_video=params.display_video
+        environment_name,
+        agent_name,
+        num_steps,
+        redis_port=DEFAULT_REDIS_PORT,
+        video_fps=video_fps,
+        display_video=display_video
     )
 
     # Once this script terminates in any way, redis_process and device_process should terminate as well.
@@ -128,3 +168,16 @@ if __name__ == '__main__':
 
     # Launch the Multivac.
     multivac.launch()
+
+
+if __name__ == '__main__':
+    params = parse_args()
+
+    start_multivac_session(
+        environment_name=params.environment_name,
+        agent_name=params.agent_name,
+        num_steps=params.num_steps,
+        observation_delta=params.observation_delta,
+        video_fps=params.video_fps,
+        display_video=params.display_video
+    )

--- a/session/session_starter.py
+++ b/session/session_starter.py
@@ -94,9 +94,6 @@ def parse_args():
     """
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--' + MONKEYRUNNER_PATH, type=str, required=True,
-                        help="Local filepath to installed monkeyrunner cmd")
-    parser.add_argument('--' + REDISPY_PATH, type=str, required=True, help="Local filepath to installed redispy source")
     parser.add_argument('--' + ENVIRONMENT_NAME, type=str, required=True, choices=ENVIRONMENTS.keys(),
                         help="Name of the environment to start")
     parser.add_argument('--' + AGENT_NAME, type=str, required=True, choices=AGENTS.keys(),


### PR DESCRIPTION
This PR reworks certain aspects of the session flow to allow for more robustness:
1. Introduce a new reset functionality by a custom `adb shell` command to close open applications. It is not only quicker, but also correct in not preserving state as best as possible than the previous method of rebooting the device which takes forever and still preserves state.
2. Get rid of notion of training and inference. We want the agent to learn on the fly.
3. Making session start an API so that the UI can start a session as well. Migrate the cmd line session start to use this API. This also involved introducing a `run_config.json` file that contains information on the monkeyrunner and redispy path.
4. Finally, after many tries, get the graceful termination of all processes correct. This finally avoids the problem of "rogue" processes that interfere and cause errors in future runs.
5. Add retry steps for device screenshot errors. This seldom occurs, but we add this for a little robustness.
6. Change print statements to logging