### PR TITLE
Dynamically retrieve device dimensions and fix BGR color issue for saved video

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ There are two separate environments to consider:
    
 ### Running a Session from Command Line
 1. Connect an Android device either through USB or open an emulated device through
-   Android Studio.
+   Android Studio. Any device should work as the dimensions of the device are dynamically loaded!
 2. Ensure the current working directory is right under `Multivac/` and the virtualenv
 from setup is activated. Then, launch the `session_starter.py` script as follows:
 ```bash

--- a/device/connection_client.py
+++ b/device/connection_client.py
@@ -56,14 +56,19 @@ class ConnectionClient:
 
     def start(self):
         """
-        Starts an infinite cycle of listening to the action buffer and populating the observation buffer.
+        First, send a screenshot message to the observation buffer to provide an example image response. Then,
+        start an infinite cycle of listening to the action buffer and populating the observation buffer.
         Once terminated, the shutdown function will be invoked.
 
-        Reads action from the action_buffer and applies it to the device. Then waits observation_delta milliseconds
-        and takes a screenshot of the device.
+        In each iteration, read action from the action_buffer and apply it to the device. Then wait observation_delta
+        milliseconds and take a screenshot of the device.
         """
 
         try:
+            # Initial step is to pass a screenshot into the observation buffer
+            self.logger.debug("Sending inital observation image")
+            self.gather_observation()
+
             while True:
                 action = self.action_buffer.blocking_read_elem()
                 self.take_action(action)

--- a/environment/android_device_env.py
+++ b/environment/android_device_env.py
@@ -115,12 +115,7 @@ class AndroidDeviceEnv(gym.Env, ABC):
         # Blocking read from the observation buffer.
         observation = self.observation_buffer.blocking_read_elem()
 
-        # Decode image bytes into a numpy array.
-        pil_image = Image.open(BytesIO(observation.image_bytes)).convert('RGB')
-
-        image_arr = np.array(pil_image)
-
-        return image_arr
+        return AndroidDeviceEnv.process_image_from_observation(observation)
 
     def compute_reward(self, new_observation):
         """
@@ -135,3 +130,18 @@ class AndroidDeviceEnv(gym.Env, ABC):
         """
 
         raise NotImplementedError
+
+    @staticmethod
+    def process_image_from_observation(observation):
+        """
+        Helper static method to process an image from an observation to a numpy array
+        :param observation: Observation object
+        :return: numpy array of an RGB image contained in the observation
+        """
+
+        # Decode image bytes into a numpy array.
+        pil_image = Image.open(BytesIO(observation.image_bytes)).convert('RGB')
+
+        image_arr = np.array(pil_image)
+
+        return image_arr

--- a/eventobjects/observation.py
+++ b/eventobjects/observation.py
@@ -3,7 +3,7 @@ import pickle
 
 class Observation(object):
     """
-    Observation object that designates a response image of the mobile screen.
+    Observation object that designates a response from the device.
     """
 
     def __init__(self, image_bytes):

--- a/session/multivac.py
+++ b/session/multivac.py
@@ -164,4 +164,7 @@ class Multivac:
 
         full_img = np.concatenate([text_img, rendered_img])
 
-        self.video_writer.write(full_img)
+        # OpenCV video writer requires image in BGR format
+        bgr_full_img = cv2.cvtColor(full_img, cv2.COLOR_RGB2BGR)
+
+        self.video_writer.write(bgr_full_img)

--- a/session/multivac.py
+++ b/session/multivac.py
@@ -30,7 +30,7 @@ class Multivac:
         Initialize the Multivac. This involves,
           1. Open a redis client and setting up an action and observation buffer. This establishes an exchange
              protocol between the Multivac and a ConnectionClient
-          2. Gather device metadata from the observation buffer
+          2. Gather an initial observation from the observation buffer to collect metadata information
           3. Initialize an environment and an agent in that environment
           4. Setup the video recorder and writer
 
@@ -56,7 +56,7 @@ class Multivac:
         action_buffer = ActionBuffer(self.redis_client)
         observation_buffer = ObservationBuffer(self.redis_client)
 
-        # Stall until we get the first observation from the observation buffer to gather image height and width
+        # Stall until we get the first observation from the observation buffer to collect metadata
         self.logger.debug("Gathering initial image from observation buffer")
         initial_observation = observation_buffer.blocking_read_elem()
         initial_image_from_observation = AndroidDeviceEnv.process_image_from_observation(initial_observation)
@@ -165,6 +165,6 @@ class Multivac:
         full_img = np.concatenate([text_img, rendered_img])
 
         # OpenCV video writer requires image in BGR format
-        bgr_full_img = cv2.cvtColor(full_img, cv2.COLOR_RGB2BGR)
+        full_img_bgr = cv2.cvtColor(full_img, cv2.COLOR_RGB2BGR)
 
-        self.video_writer.write(bgr_full_img)
+        self.video_writer.write(full_img_bgr)

--- a/session/session_starter.py
+++ b/session/session_starter.py
@@ -189,21 +189,20 @@ def start_multivac_session(environment_name, agent_name, num_steps, observation_
         signal.signal(signal.SIGINT, terminate_on_signal)
         signal.signal(signal.SIGTERM, terminate_on_signal)
 
-    # Set up the Multivac
-    multivac = Multivac(
-        environment_name,
-        agent_name,
-        num_steps,
-        redis_port=static_configs.DEFAULT_REDIS_PORT,
-        video_fps=video_fps,
-        display_video=display_video
-    )
-
-    # Launch the Multivac.
+    # Set up and launch the Multivac
     try:
+        multivac = Multivac(
+            environment_name,
+            agent_name,
+            num_steps,
+            redis_port=static_configs.DEFAULT_REDIS_PORT,
+            video_fps=video_fps,
+            display_video=display_video
+        )
+
         multivac.launch()
     except Exception as e:
-        logger.error("Multivac has thrown an exception: {}".format(e))
+        logger.exception("Multivac has thrown an exception: {}".format(e))
         terminate()
         return SessionStatusEnum.FAILED
 


### PR DESCRIPTION
* Modify `ConnectionClient` logic to start off by placing an initial observation into the observation buffer. This is to allow the `Multivac` to resolve the device dimensions before proceeding
* Convert RGB frame for an observation to BGR format for the OpenCV video writer. The video writer now saves an appropriate video with proper colors